### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,1 @@
-certora-vat	:;certoraRun --solc ~/.solc-select/artifacts/solc-0.8.13 Vat.sol --verify Vat:Vat.spec --rule_sanity --multi_assert_check
+certora-vat	:;certoraRun --solc ~/.solc-select/artifacts/solc-0.8.13 Vat.sol --verify Vat:Vat.spec


### PR DESCRIPTION
Removing two flags.
`--rule_sanity` increases run time, and is not relevant for the purpose of finding the bug
`--multi_assert_check` is not relevant for this simplified spec, as there are no rules with more than one assertion
I verified that running without those flags outputs the same counter example.