### PR TITLE
Run fundamental equation of DAI with cvl2

### DIFF
--- a/Vat.spec
+++ b/Vat.spec
@@ -1,8 +1,8 @@
 // Vat.spec
 
 methods {
-    debt() returns (uint256) envfree
-    vice() returns (uint256) envfree
+    function debt() external returns (uint256) envfree;
+    function vice() external returns (uint256) envfree;
 }
 
 ghost sumOfVaultDebtGhost() returns uint256 {
@@ -17,24 +17,24 @@ ghost mapping(bytes32 => uint256) ArtGhost {
     init_state axiom forall bytes32 ilk. ArtGhost[ilk] == 0;
 }
 
-hook Sload uint256 v currentContract.ilks[KEY bytes32 ilk].(offset 0) STORAGE {
+hook Sload uint256 v currentContract.ilks[KEY bytes32 ilk].(offset 0) {
     require ArtGhost[ilk] == v;
 }
 
-hook Sstore currentContract.ilks[KEY bytes32 ilk].(offset 0) uint256 newArt (uint256 oldArt) STORAGE {
-    havoc sumOfVaultDebtGhost assuming sumOfVaultDebtGhost@new() == sumOfVaultDebtGhost@old() + (newArt * rateGhost[ilk]) - (oldArt * rateGhost[ilk]);
+hook Sstore currentContract.ilks[KEY bytes32 ilk].(offset 0) uint256 newArt (uint256 oldArt) {
+    havoc sumOfVaultDebtGhost assuming sumOfVaultDebtGhost@new() == assert_uint256(sumOfVaultDebtGhost@old() + (newArt * rateGhost[ilk]) - (oldArt * rateGhost[ilk]));
     ArtGhost[ilk] = newArt;
 }
 
-hook Sload uint256 v currentContract.ilks[KEY bytes32 ilk].(offset 32) STORAGE {
+hook Sload uint256 v currentContract.ilks[KEY bytes32 ilk].(offset 32) {
     require rateGhost[ilk] == v;
 }
 
-hook Sstore currentContract.ilks[KEY bytes32 ilk].(offset 32) uint256 newRate (uint256 oldRate) STORAGE {
-    havoc sumOfVaultDebtGhost assuming sumOfVaultDebtGhost@new() == sumOfVaultDebtGhost@old() + (ArtGhost[ilk] * newRate) - (ArtGhost[ilk] * oldRate);
+hook Sstore currentContract.ilks[KEY bytes32 ilk].(offset 32) uint256 newRate (uint256 oldRate) {
+    havoc sumOfVaultDebtGhost assuming sumOfVaultDebtGhost@new() == assert_uint256(sumOfVaultDebtGhost@old() + (ArtGhost[ilk] * newRate) - (ArtGhost[ilk] * oldRate));
     rateGhost[ilk] = newRate;
 }
 
 invariant fundamental_equation_of_dai()
-   debt() == vice() + sumOfVaultDebtGhost()
+   debt() == assert_uint256(vice() + sumOfVaultDebtGhost())
    filtered { f -> !f.isFallback }


### PR DESCRIPTION
The new version of the prover uses CVL2. 
Modifying the spec file below to CVL2 to run with the latest prover version.